### PR TITLE
Allow the top karma command in DMs without explicit mention

### DIFF
--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -96,7 +96,7 @@ final class KarmaService: SlackMessageService {
         if message.text.lowercased().hasPrefix(self.topKarmaCommand(bot: slackBot)) { // Top karma users command
             if
                 let listCountText = message.text
-                    .substring(from: topKarmaCommand(bot: slackBot).characters.count)
+                    .substring(from: topKarmaCommand(bot: slackBot).endIndex)
                     .components(separatedBy: " ")
                     .first(where: { !$0.isEmpty }),
                 let listCount = Int(listCountText)

--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -91,12 +91,14 @@ final class KarmaService: SlackMessageService {
     func messageEvent(slackBot: SlackBot, webApi: WebAPI, message: MessageDecorator, previous: MessageDecorator?) throws {
         guard let target = message.target, self.isKarmaChannel(target) else { return }
         
+        let topKarmaCommand = self.topKarmaCommand(bot: slackBot)
+        
         let response: String
         
-        if message.text.lowercased().hasPrefix(self.topKarmaCommand(bot: slackBot)) { // Top karma users command
+        if message.text.lowercased().hasPrefix(topKarmaCommand) { // Top karma users command
             if
                 let listCountText = message.text
-                    .substring(from: topKarmaCommand(bot: slackBot).endIndex)
+                    .substring(from: topKarmaCommand.endIndex)
                     .components(separatedBy: " ")
                     .first(where: { !$0.isEmpty }),
                 let listCount = Int(listCountText)

--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -97,7 +97,7 @@ final class KarmaService: SlackMessageService {
             if
                 let listCountText = message.text
                     .substring(from: topKarmaCommand(bot: slackBot).characters.count)
-                    .components(separatedBy: " ").filter({ $0.characters.count != 0 }).first,
+                    .components(separatedBy: " ").filter({ !$0.isEmpty }).first,
                 let listCount = Int(listCountText)
             {
                 response = topKarma(maxList: listCount, in: slackBot.storage)

--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -93,7 +93,7 @@ final class KarmaService: SlackMessageService {
         
         let response: String
         
-        if (message.text.lowercased().hasPrefix(self.topKarmaCommand(bot: slackBot))) { // Top karma users command
+        if message.text.lowercased().hasPrefix(self.topKarmaCommand(bot: slackBot)) { // Top karma users command
             if
                 let listCountText = message.text
                     .substring(from: topKarmaCommand(bot: slackBot).characters.count)

--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -91,7 +91,8 @@ final class KarmaService: SlackMessageService {
     func messageEvent(slackBot: SlackBot, webApi: WebAPI, message: MessageDecorator, previous: MessageDecorator?) throws {
         guard let target = message.target, self.isKarmaChannel(target) else { return }
         
-        let topKarmaCommand = self.topKarmaCommand(bot: slackBot)
+        let isDirectMessage = message.message.channel?.value.instantMessage != nil
+        let topKarmaCommand = self.topKarmaCommand(bot: slackBot, isDirectMessage: isDirectMessage)
         
         let response: String
         

--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -181,8 +181,8 @@ final class KarmaService: SlackMessageService {
         guard let targets = self.options.targets else { return true }
         return targets.contains { $0 == target.name || $0 == "*" }
     }
-    private func topKarmaCommand(bot: SlackBot) -> String {
-        return "<@\(bot.me.id)> top".lowercased()
+    private func topKarmaCommand(bot: SlackBot, isDirectMessage: Bool = false) -> String {
+        return isDirectMessage ? "top" : "<@\(bot.me.id.lowercased())> top"
     }
     private func topKarma(maxList: Int, in storage: Storage) -> String {
         guard maxList > 0 else { return "Top \(maxList)? You must work in QA." }

--- a/Sources/Camille/KarmaService.swift
+++ b/Sources/Camille/KarmaService.swift
@@ -97,7 +97,8 @@ final class KarmaService: SlackMessageService {
             if
                 let listCountText = message.text
                     .substring(from: topKarmaCommand(bot: slackBot).characters.count)
-                    .components(separatedBy: " ").filter({ !$0.isEmpty }).first,
+                    .components(separatedBy: " ")
+                    .first(where: { !$0.isEmpty }),
                 let listCount = Int(listCountText)
             {
                 response = topKarma(maxList: listCount, in: slackBot.storage)


### PR DESCRIPTION
This change allows users to direct message Camille something like “top 10” without having to explicitly mention her.
